### PR TITLE
fix(FAQSummary): clickable area of an expand

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -248,12 +248,11 @@ details summary {
 }
 
 .faq details {
-  padding: 1.25rem 0;
   border-top: 1px solid #f1efef;
 }
 
-.faq details:not(:last-child) {
-  margin-bottom: 1rem;
+.faq details p {
+  margin: 0 0 2.5rem;
 }
 
 .faq details:last-child {
@@ -266,6 +265,7 @@ details summary {
   padding-right: 3rem;
   color: #444444;
   font-weight: bold;
+  padding: 1.7rem 0;
 }
 
 .faq summary::before {
@@ -283,6 +283,10 @@ details summary {
   top: 50%;
   right: 0;
   transform: translateY(-50%);
+}
+
+.faq details[open] summary {
+  padding-bottom: 1rem;
 }
 
 .faq details[open] summary::after {


### PR DESCRIPTION
Algumas vezes apanhei um pouco pra expandir e ler as respostas da FAQ.

Tentei demonstrar no gif. Tem o antes e depois ;)

![faq-clickable-area](https://user-images.githubusercontent.com/19298150/154787033-eee4b7c9-9148-4999-b2a8-4a811d963e97.gif)
