### PR TITLE
css: remove sobreposição do sumário no icone abrir

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -265,7 +265,7 @@ details summary {
   padding-right: 3rem;
   color: #444444;
   font-weight: bold;
-  padding: 1.7rem 0;
+  padding: 1.7rem 1rem 1.7rem 0;
 }
 
 .faq summary::before {


### PR DESCRIPTION
antes:
![image](https://user-images.githubusercontent.com/1766903/155387152-567ee44e-6b59-445c-9607-df0783ea9443.png)

depois:
![image](https://user-images.githubusercontent.com/1766903/155387443-7e9e752f-18e1-427f-9664-f4ad94311cbc.png)

